### PR TITLE
feat: add general-purpose Qwen AI models (Max, Plus, 235B, Flash)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <img src="assets/screenshot.png" alt="OpenCode with Qwen Code" width="800">
 </p>
 
-**Authenticate OpenCode CLI with your qwen.ai account.** This plugin enables you to use Qwen3-Coder models with **2,000 free requests per day** - no API key or credit card required!
+**Authenticate OpenCode CLI with your qwen.ai account.** This plugin enables you to use Qwen models (Coder, Max, Plus and more) with **2,000 free requests per day** - no API key or credit card required!
 
 [🇧🇷 Leia em Português](./README.pt-BR.md)
 
@@ -69,22 +69,35 @@ Select **"Qwen Code (qwen.ai OAuth)"**
 
 ## 🎯 Available Models
 
+### Coding Models
+
 | Model | Context | Max Output | Best For |
 |-------|---------|------------|----------|
 | `qwen3-coder-plus` | 1M tokens | 64K tokens | Complex coding tasks |
-| `qwen3-coder-flash` | 1M tokens | 64K tokens | Fast responses |
+| `qwen3-coder-flash` | 1M tokens | 64K tokens | Fast coding responses |
+
+### General Purpose Models
+
+| Model | Context | Max Output | Reasoning | Best For |
+|-------|---------|------------|-----------|----------|
+| `qwen3-max` | 256K tokens | 64K tokens | No | Flagship model, complex reasoning and tool use |
+| `qwen-plus-latest` | 128K tokens | 16K tokens | Yes | Balanced quality-speed with thinking mode |
+| `qwen3-235b-a22b` | 128K tokens | 32K tokens | Yes | Largest open-weight MoE with thinking mode |
+| `qwen-flash` | 1M tokens | 8K tokens | No | Ultra-fast, low-cost simple tasks |
 
 ### Using a specific model
 
 ```bash
 opencode --provider qwen-code --model qwen3-coder-plus
+opencode --provider qwen-code --model qwen3-max
+opencode --provider qwen-code --model qwen-plus-latest
 ```
 
 ## ⚙️ How It Works
 
 ```
 ┌─────────────────┐     ┌──────────────────┐     ┌─────────────────┐
-│   OpenCode CLI  │────▶│  qwen.ai OAuth   │────▶│  Qwen3-Coder    │
+│   OpenCode CLI  │────▶│  qwen.ai OAuth   │────▶│  Qwen Models    │
 │                 │◀────│  (Device Flow)   │◀────│  API            │
 └─────────────────┘     └──────────────────┘     └─────────────────┘
 ```

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -8,7 +8,7 @@
   <img src="assets/screenshot.png" alt="OpenCode com Qwen Code" width="800">
 </p>
 
-**Autentique o OpenCode CLI com sua conta qwen.ai.** Este plugin permite usar modelos Qwen3-Coder com **2.000 requisições gratuitas por dia** - sem API key ou cartão de crédito!
+**Autentique o OpenCode CLI com sua conta qwen.ai.** Este plugin permite usar modelos Qwen (Coder, Max, Plus e mais) com **2.000 requisições gratuitas por dia** - sem API key ou cartão de crédito!
 
 [🇺🇸 Read in English](./README.md)
 
@@ -69,22 +69,35 @@ Selecione **"Qwen Code (qwen.ai OAuth)"**
 
 ## 🎯 Modelos Disponíveis
 
+### Modelos de Código
+
 | Modelo | Contexto | Max Output | Melhor Para |
 |--------|----------|------------|-------------|
 | `qwen3-coder-plus` | 1M tokens | 64K tokens | Tarefas complexas de código |
-| `qwen3-coder-flash` | 1M tokens | 64K tokens | Respostas rápidas |
+| `qwen3-coder-flash` | 1M tokens | 64K tokens | Respostas rápidas de código |
+
+### Modelos de Propósito Geral
+
+| Modelo | Contexto | Max Output | Reasoning | Melhor Para |
+|--------|----------|------------|-----------|-------------|
+| `qwen3-max` | 256K tokens | 64K tokens | Não | Modelo flagship, raciocínio complexo e tool use |
+| `qwen-plus-latest` | 128K tokens | 16K tokens | Sim | Equilíbrio qualidade-velocidade com thinking mode |
+| `qwen3-235b-a22b` | 128K tokens | 32K tokens | Sim | Maior modelo open-weight MoE com thinking mode |
+| `qwen-flash` | 1M tokens | 8K tokens | Não | Ultra-rápido, baixo custo para tarefas simples |
 
 ### Usando um modelo específico
 
 ```bash
 opencode --provider qwen-code --model qwen3-coder-plus
+opencode --provider qwen-code --model qwen3-max
+opencode --provider qwen-code --model qwen-plus-latest
 ```
 
 ## ⚙️ Como Funciona
 
 ```
 ┌─────────────────┐     ┌──────────────────┐     ┌─────────────────┐
-│   OpenCode CLI  │────▶│  qwen.ai OAuth   │────▶│  Qwen3-Coder    │
+│   OpenCode CLI  │────▶│  qwen.ai OAuth   │────▶│  Qwen Models    │
 │                 │◀────│  (Device Flow)   │◀────│  API            │
 └─────────────────┘     └──────────────────┘     └─────────────────┘
 ```

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "opencode-qwen-auth",
@@ -7,6 +8,7 @@
         "open": "^10.1.0",
       },
       "devDependencies": {
+        "@opencode-ai/plugin": "^1.1.48",
         "@types/node": "^22.0.0",
         "bun-types": "^1.1.0",
         "typescript": "^5.6.0",
@@ -14,6 +16,10 @@
     },
   },
   "packages": {
+    "@opencode-ai/plugin": ["@opencode-ai/plugin@1.1.53", "", { "dependencies": { "@opencode-ai/sdk": "1.1.53", "zod": "4.1.8" } }, "sha512-9ye7Wz2kESgt02AUDaMea4hXxj6XhWwKAG8NwFhrw09Ux54bGaMJFt1eIS8QQGIMaD+Lp11X4QdyEg96etEBJw=="],
+
+    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.1.53", "", {}, "sha512-RUIVnPOP1CyyU32FrOOYuE7Ge51lOBuhaFp2NSX98ncApT7ffoNetmwzqrhOiJQgZB1KrbCHLYOCK6AZfacxag=="],
+
     "@types/node": ["@types/node@22.19.7", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw=="],
 
     "bun-types": ["bun-types@1.3.8", "", { "dependencies": { "@types/node": "*" } }, "sha512-fL99nxdOWvV4LqjmC+8Q9kW3M4QTtTR1eePs94v5ctGqU8OeceWrSUaRw3JYb7tU3FkMIAjkueehrHPPPGKi5Q=="],
@@ -41,5 +47,7 @@
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "wsl-utils": ["wsl-utils@0.1.0", "", { "dependencies": { "is-wsl": "^3.1.0" } }, "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw=="],
+
+    "zod": ["zod@4.1.8", "", {}, "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opencode-qwencode-auth",
-  "version": "1.1.0",
-  "description": "Qwen OAuth authentication plugin for OpenCode - Access Qwen3-Coder models with your qwen.ai account",
+  "version": "1.2.0",
+  "description": "Qwen OAuth authentication plugin for OpenCode - Access Qwen AI models (Coder, Max, Plus and more) with your qwen.ai account",
   "module": "index.ts",
   "type": "module",
   "scripts": {
@@ -14,6 +14,9 @@
     "qwen",
     "qwen-code",
     "qwen3-coder",
+    "qwen3-max",
+    "qwen-plus",
+    "qwen-flash",
     "oauth",
     "authentication",
     "ai",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -35,14 +35,16 @@ export const QWEN_API_CONFIG = {
 export const CALLBACK_PORT = 14561;
 
 // Available Qwen models through OAuth
-// Baseado nos modelos disponíveis no qwen-code
+// Baseado nos modelos disponíveis no qwen-code + modelos gerais via portal.qwen.ai
 export const QWEN_MODELS = {
+  // --- Coding Models ---
   'qwen3-coder-plus': {
     id: 'qwen3-coder-plus',
     name: 'Qwen3 Coder Plus',
     contextWindow: 1048576, // 1M tokens
     maxOutput: 65536, // 64K tokens
     description: 'Most capable Qwen coding model with 1M context window',
+    reasoning: false,
     cost: { input: 0, output: 0 }, // Free via OAuth
   },
   'qwen3-coder-flash': {
@@ -51,6 +53,44 @@ export const QWEN_MODELS = {
     contextWindow: 1048576,
     maxOutput: 65536,
     description: 'Faster Qwen coding model for quick responses',
+    reasoning: false,
+    cost: { input: 0, output: 0 },
+  },
+  // --- General Purpose Models ---
+  'qwen3-max': {
+    id: 'qwen3-max',
+    name: 'Qwen3 Max',
+    contextWindow: 262144, // 256K tokens
+    maxOutput: 65536, // 64K tokens
+    description: 'Flagship ~1T parameter MoE model, best for complex reasoning and tool use',
+    reasoning: false,
+    cost: { input: 0, output: 0 },
+  },
+  'qwen-plus-latest': {
+    id: 'qwen-plus-latest',
+    name: 'Qwen Plus',
+    contextWindow: 131072, // 128K tokens
+    maxOutput: 16384, // 16K tokens
+    description: 'Balanced model with thinking mode, good quality-speed tradeoff',
+    reasoning: true,
+    cost: { input: 0, output: 0 },
+  },
+  'qwen3-235b-a22b': {
+    id: 'qwen3-235b-a22b',
+    name: 'Qwen3 235B-A22B',
+    contextWindow: 131072, // 128K tokens
+    maxOutput: 32768, // 32K tokens
+    description: 'Largest open-weight Qwen3 MoE model with thinking mode',
+    reasoning: true,
+    cost: { input: 0, output: 0 },
+  },
+  'qwen-flash': {
+    id: 'qwen-flash',
+    name: 'Qwen Flash',
+    contextWindow: 1048576, // 1M tokens
+    maxOutput: 8192, // 8K tokens
+    description: 'Ultra-fast and low-cost model for simple tasks',
+    reasoning: false,
     cost: { input: 0, output: 0 },
   },
 } as const;

--- a/src/index.ts
+++ b/src/index.ts
@@ -214,7 +214,7 @@ export const QwenAuthPlugin = async (_input: unknown) => {
             {
               id: m.id,
               name: m.name,
-              reasoning: false,
+              reasoning: m.reasoning,
               limit: { context: m.contextWindow, output: m.maxOutput },
               cost: m.cost,
               modalities: { input: ['text'], output: ['text'] },


### PR DESCRIPTION
Expand available models beyond Coder-only to include qwen3-max (flagship),
qwen-plus-latest (balanced with thinking mode), qwen3-235b-a22b (largest
open-weight MoE), and qwen-flash (ultra-fast). Models with thinking/reasoning
support are now properly flagged.

https://claude.ai/code/session_01QbLDbB9p722ttQjJbq5QFz