### PR TITLE
fix: ship compiled dist/ instead of TypeScript source

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,11 +2,12 @@
   "name": "opencode-qwencode-auth",
   "version": "1.3.0",
   "description": "Qwen OAuth authentication plugin for OpenCode - Access Qwen AI models (Coder, Vision) with your qwen.ai account",
-  "module": "index.ts",
+  "module": "dist/index.js",
   "type": "module",
   "scripts": {
     "build": "bun build ./src/index.ts --outdir ./dist --target node --format esm && bun build ./src/cli.ts --outdir ./dist --target node --format esm",
     "dev": "bun run --watch src/index.ts",
+    "prepublishOnly": "bun run build",
     "typecheck": "tsc --noEmit"
   },
   "keywords": [
@@ -39,8 +40,7 @@
     "typescript": "^5.6.0"
   },
   "files": [
-    "index.ts",
-    "src",
+    "dist",
     "README.md"
   ],
   "engines": {


### PR DESCRIPTION
## Problem

The published npm package (`opencode-qwencode-auth@1.3.0`) contains only TypeScript source files (`.ts`), but OpenCode's ESM plugin loader resolves imports with `.js` extensions. This causes the plugin to fail loading with:

```
ENOENT: no such file or directory, open '.../src/constants.js'
failed to load plugin
```

## Changes

- **`module`**: Changed from `index.ts` to `dist/index.js` (compiled output)
- **`scripts.prepublishOnly`**: Added `bun run build` to auto-build `dist/` before every `npm publish`
- **`files`**: Updated to ship `dist/` + README.md instead of raw TypeScript source

## Verification

- [x] `bun run build` produces `dist/index.js` and `dist/cli.js`
- [x] `npm pack` includes `dist/` in tarball  
- [x] Tested in OpenCode v1.14.29 — plugin loads successfully
- [x] `opencode auth login` shows "Qwen Code" provider
- [x] OAuth flow completes, models available

## Related Issues

- Closes #15
- Related to #14